### PR TITLE
Use KSPRootPath/PluginData to store user functions

### DIFF
--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -124,7 +124,6 @@ namespace Kerbulator {
 			// Use the game base directory + PluginData as base folder for plugin data
 			functionDir = KSPUtil.ApplicationRootPath + "/PluginData" + "/Kerbulator";
 			functionDir = functionDir.Replace("\\", "/");
-			if (functionDir.EndsWith("/")) functionDir = functionDir.Substring(0, functionDir.Length - 1);
 
 			Debug.Log("Kerbulator function dir: "+ functionDir);
 

--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -121,18 +121,10 @@ namespace Kerbulator {
 			this.drawMainButton = drawMainButton;
 			ChangeState(false);
 
-			functionDir = Application.persistentDataPath + "/Kerbulator";
-
-			// Sometimes, Application.persistentDataPath returns an empty string.
-			// To not completely crash, create a KerbulatorFunctions directory in the users home dir
-			if(functionDir == "/Kerbulator") {
-				string homePath =
-                    (Environment.OSVersion.Platform == PlatformID.Unix || 
-                     Environment.OSVersion.Platform == PlatformID.MacOSX)
-					 ? Environment.GetEnvironmentVariable("HOME")
-					 : Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
-				functionDir = homePath +"/KerbulatorFunctions";
-			}
+			// Use the game base directory + PluginData as base folder for plugin data
+			functionDir = KSPUtil.ApplicationRootPath + "/PluginData" + "/Kerbulator";
+			functionDir = functionDir.Replace("\\", "/");
+			if (functionDir.EndsWith("/")) functionDir = functionDir.Substring(0, functionDir.Length - 1);
 
 			Debug.Log("Kerbulator function dir: "+ functionDir);
 

--- a/doc/manual.mkd
+++ b/doc/manual.mkd
@@ -212,15 +212,21 @@ For all the cool things you can do with lists, take a look at what the [language
 
 ### Writing functions in your own editor
 
-Bob likes the little editor inside KSP, because it gives quick access to Greek and math symbols to make his formulae look pretty. However, when writing very long functions, you may want to use some other editor. Kerbulator stores its functions in a folder on your disk. The location depends on your platform:
+Bob likes the little editor inside KSP, because it gives quick access to Greek and math symbols to make his formulae look pretty. However, when writing very long functions, you may want to use some other editor. Kerbulator stores its functions in a folder on your disk. The location depends on your KSP installation:
+
+`{KSP folder}/PluginData/Kerbulator`
+
+Everytime you switch from KSP to some other window, Kerbulator makes sure the files on your disk are up to date. Then, when returning to the KSP window, Kerbulator reloads the functions from disk. Any editing you've done on those files (and any new files you've created) will be picked up by Kerbulator. Functions are text files in UTF-8 encoding with the extention `.math`.
+
+#### Legacy save folder location
+
+If you were using Kerbulator 0.32 or earlier, you must manually move your functions file to the new save folder location. This legacy location depends on your operative system:
 
 Platform | Location
 ---------|---------
 Windows  | `C:/Users/{username}/AppData/LocalLow/Squad/Kerbal Space Program/Kerbulator`
 OSX      | `/Users/{username}/Library/Caches/unity.Squad.Kerbal Space Program/Kerbulator`
 Linux    | `/home/{username}/.config/unity3d/Squad/Kerbal Space Program/Kerbulator`
-
-Everytime you switch from KSP to some other window, Kerbulator makes sure the files on your disk are up to date. Then, when returning to the KSP window, Kerbulator reloads the functions from disk. Any editing you've done on those files (and any new files you've created) will be picked up by Kerbulator. Functions are text files in UTF-8 encoding with the extention `.math`.
 
 ### Using the numeric solver
 


### PR DESCRIPTION
Right now the plugin is out of compliance with Squad's plugin rule 4.a "Forbidden code" because it writes its functions outside the KSP installation folder.

ApplicationRootPath from KSPUtil is used instead to save functions.