### PR TITLE
Add relative to target orbital information

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ More globals. Thanks to Emanuele Bardelli.
  - Language features
    - Fixed `{Body}.AtmosHeight` global
    - Fixed `{Body}.AtmosPress` global
+   - Added `Craft.Rel.AN` global
+   - Added `Craft.Rel.DN` global
+   - Added `Craft.Rel.Inc` global
 
 ### 0.33
 Small maintenance update. Thanks to Emanuele Bardelli.

--- a/Globals.cs
+++ b/Globals.cs
@@ -78,6 +78,10 @@ namespace Kerbulator {
 					AddDouble(kalc, "Craft.Inter2.Sep", (orbit1.getPositionAtUT(T2+UT) - orbit2.getPositionAtUT(T2+UT)).magnitude);
 					AddDouble(kalc, "Craft.Inter2.TrueAnomaly", orbit2.TrueAnomalyAtUT(T2+UT) * (180/Math.PI));
 					AddDouble(kalc, "Craft.Inter2.θ", orbit2.TrueAnomalyAtUT(T2+UT) * (180/Math.PI));
+					// Relative Ascending and Descending Nodes, Inclination
+					AddDouble(kalc, "Craft.Rel.AN", orbit1.GetTrueAnomalyOfZupVector(Vector3d.Cross(orbit2.GetOrbitNormal(), orbit1.GetOrbitNormal())) * (180 / Math.PI));
+					AddDouble(kalc, "Craft.Rel.DN", orbit1.GetTrueAnomalyOfZupVector(Vector3d.Cross(orbit1.GetOrbitNormal(), orbit2.GetOrbitNormal())) * (180 / Math.PI));
+					AddDouble(kalc, "Craft.Rel.Inc", Vector3d.Angle(orbit1.GetOrbitNormal(), orbit2.GetOrbitNormal()));
 				}
 			}
 		}

--- a/doc/globals.mkd
+++ b/doc/globals.mkd
@@ -133,4 +133,7 @@ Craft.Inter2.Δt  | Same as Craft.Inter1.dt
 Craft.Inter2.Sep | Distance (in meters) between our craft and the target at Craft.Inter2.dt
 Craft.Inter2.TrueAnomaly | True anomaly of the second time we cross the target orbit
 Craft.Inter2.θ   | Same as Craft.Inter2.TrueAnomaly
+Craft.Rel.AN     | Argument of Ascending node relative to target
+Craft.Rel.DN     | Argument of Descenging node relative to target
+Craft.Rel.Inc    | Incliation relative to target
 

--- a/doc/globals.mkd
+++ b/doc/globals.mkd
@@ -133,7 +133,6 @@ Craft.Inter2.Δt  | Same as Craft.Inter1.dt
 Craft.Inter2.Sep | Distance (in meters) between our craft and the target at Craft.Inter2.dt
 Craft.Inter2.TrueAnomaly | True anomaly of the second time we cross the target orbit
 Craft.Inter2.θ   | Same as Craft.Inter2.TrueAnomaly
-Craft.Rel.AN     | Argument of Ascending node relative to target
-Craft.Rel.DN     | Argument of Descenging node relative to target
-Craft.Rel.Inc    | Incliation relative to target
-
+Craft.Rel.AN     | True anomaly of ascending node relative to target
+Craft.Rel.DN     | True anomaly of descenging node relative to target
+Craft.Rel.Inc    | Inclination relative to target


### PR DESCRIPTION
Variables are visible only target is selected. The same information is available visually in the map view. All calculations are inspired by Kerbal Engineer's rendezvous calculator.

Documentation is also updated to reflect the new changes.