### PR TITLE
Fix atmos data

### DIFF
--- a/Globals.cs
+++ b/Globals.cs
@@ -140,8 +140,8 @@ namespace Kerbulator {
             AddDouble(kalc, prefix +".µ", (double)body.gravParameter);
 			AddDouble(kalc, prefix +".day", (double)body.rotationPeriod);
 			AddDouble(kalc, prefix +".SOI", (double)body.sphereOfInfluence);
-			//AddDouble(kalc, prefix +".AtmosHeight", (double)body.maxAtmosphereAltitude);
-			//AddDouble(kalc, prefix +".AtmosPress", (double)body.atmosphereMultiplier * 101325.0);
+			AddDouble(kalc, prefix +".AtmosHeight", (double)(body.atmosphere ? body.atmosphereDepth : 0));
+			AddDouble(kalc, prefix +".AtmosPress", (double)(body.atmosphere ? body.atmospherePressureSeaLevel : 0));
 		}
 
 		public static void AddDouble(Kerbulator kalc, string id, double v) {


### PR DESCRIPTION
AtmosHeight and AtmosPress use the new 1.0 body properties.

I also added a check for atmosphere-less bodies. They will return 0 by default.