### PR TITLE
Multiple maneuvers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 Changelog
 ---------
+### 0.5
+The mechanics for creating maneuvers and alarms have been overhauled. See the
+manual and language reference for the new syntax. Thanks to Thorulf Neustrup!
+
+ - Language features:
+   - New notation for defining maneuvers
+   - New notation for defining alarms
+   - Added ability to create multiple maneuvers and alarms in a single function
+
 ### 0.46
 Bugfixes.
  - GUI features:

--- a/ExecutionEnvironment.cs
+++ b/ExecutionEnvironment.cs
@@ -40,15 +40,6 @@ namespace Kerbulator {
 			protected set { }
 		}
 
-		//Return a list of outputs marked as maneuver nodes
-		public List<System.Object> ManeuverOutput
-        {
-			get {
-				int i = 0;
-				return output.Where(o => func.OutIsManeuverNode[i++]).ToList();
-			}
-        }
-
 		public List<System.Object> Execute() {
 			inError = false;
 			error = null;
@@ -77,6 +68,11 @@ namespace Kerbulator {
 				return null;
 			}
 		}
+
+        public List<System.Object> GetOutputsOfType(OutputType type) {
+            int i = 0;
+            return output.Where(o => func.OutputTypes[i++] == type).ToList();
+        }
 
 		public void SetArguments(List<string> args) {
 			if(args.Count != func.Ins.Count) {

--- a/ExecutionEnvironment.cs
+++ b/ExecutionEnvironment.cs
@@ -40,6 +40,15 @@ namespace Kerbulator {
 			protected set { }
 		}
 
+		//Return a list of outputs marked as maneuver nodes
+		public List<System.Object> ManeuverOutput
+        {
+			get {
+				int i = 0;
+				return output.Where(o => func.OutIsManeuverNode[i++]).ToList();
+			}
+        }
+
 		public List<System.Object> Execute() {
 			inError = false;
 			error = null;

--- a/GameGlue.cs
+++ b/GameGlue.cs
@@ -196,10 +196,6 @@ namespace Kerbulator {
 
 		public void PlaceNodes(List<string> ids, List<object> maneuverNodes, List<System.Object> output)
         {
-			Debug.Log("Got a new thing");
-			Debug.Log(ids.Count);
-			Debug.Log(maneuverNodes.Count);
-
 			//Places a node using the old system for backwards capability
             PlaceNode(ids, output);
 

--- a/GameGlue.cs
+++ b/GameGlue.cs
@@ -294,7 +294,6 @@ namespace Kerbulator {
                 if(oldNotationAlarm != null)
                     alarms = alarms.Append(oldNotationAlarm).ToList();
 
-                
                 for(int i = 0; i<alarms.Count; i ++) {
                     double alarmTime = (double)alarms[i];
 

--- a/GameGlue.cs
+++ b/GameGlue.cs
@@ -201,9 +201,9 @@ namespace Kerbulator {
             foreach(object[] maneuver in maneuverNodes) {
 				double dr, dn, dp;
 
-				dr = (double)maneuver[0];
+				dp = (double)maneuver[0];
 				dn = (double)maneuver[1];
-				dp = (double)maneuver[2];
+				dr = (double)maneuver[2];
 
 				double UT = (double)maneuver[3] + Planetarium.GetUniversalTime();
 				Vector3d dV = new Vector3d(dr, dn, dp);

--- a/GameGlue.cs
+++ b/GameGlue.cs
@@ -194,13 +194,11 @@ namespace Kerbulator {
 			Globals.Add(kalc); // UNITY
 		}
 
-		public void PlaceNodes(List<string> ids, List<object> maneuverNodes, List<System.Object> output)
-        {
+		public void PlaceNodes(List<string> ids, List<object> maneuverNodes, List<System.Object> output) {
 			//Places a node using the old system for backwards capability
             PlaceNode(ids, output);
 
-            foreach (object[] maneuver in maneuverNodes)
-            {
+            foreach(object[] maneuver in maneuverNodes) {
 				double dr, dn, dp;
 
 				dr = (double)maneuver[0];
@@ -214,26 +212,24 @@ namespace Kerbulator {
             }
         }
 
-        private void PlaceNode(List<string> ids, List<object> output)
-        {
+        private void PlaceNode(List<string> ids, List<object> output) {
             double dr = 0, dn = 0, dp = 0;
             double UT = 0;
 
             // Look at the resulting variables and create a maneuver node with them
-            for (int i = 0; i < ids.Count; i++)
-            {
-                if (output[i].GetType() != typeof(double))
+            for(int i = 0; i < ids.Count; i++) {
+                if(output[i].GetType() != typeof(double))
                     continue;
 
                 string id = ids[i];
                 double val = (double)output[i];
-                if (id == "Δv_r" || id == "dv_r")
+                if(id == "Δv_r" || id == "dv_r")
                     dr = val;
-                else if (id == "Δv_n" || id == "dv_n")
+                else if(id == "Δv_n" || id == "dv_n")
                     dn = val;
-                else if (id == "Δv_p" || id == "dv_p")
+                else if(id == "Δv_p" || id == "dv_p")
                     dp = val;
-                else if (id == "Δt" || id == "dt")
+                else if(id == "Δt" || id == "dt")
                     UT = val + Planetarium.GetUniversalTime();
             }
 
@@ -243,24 +239,20 @@ namespace Kerbulator {
 				CreateManeuverNode(UT, dV);
         }
 
-        private void CreateManeuverNode(double UT, Vector3d dV)
-        {
+        private void CreateManeuverNode(double UT, Vector3d dV) {
             Vessel vessel = FlightGlobals.ActiveVessel;
-            if (vessel == null)
+            if(vessel == null)
                 return;
 
             //placing a maneuver node with bad dV values can really mess up the game, so try to protect against that
             //and log an exception if we get a bad dV vector:
-            for (int i = 0; i < 3; i++)
-            {
-                if (double.IsNaN(dV[i]) || double.IsInfinity(dV[i]))
-                {
+            for (int i = 0; i < 3; i++) {
+                if (double.IsNaN(dV[i]) || double.IsInfinity(dV[i])) {
                     throw new Exception("Kerbulator: bad dV: " + dV);
                 }
             }
 
-            if (double.IsNaN(UT) || double.IsInfinity(UT))
-            {
+            if (double.IsNaN(UT) || double.IsInfinity(UT)) {
                 throw new Exception("Kerbulator: bad UT: " + UT);
             }
 

--- a/JITFunction.cs
+++ b/JITFunction.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq.Expressions;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Linq;
 
 namespace Kerbulator {
 	public class JITFunction {
@@ -1294,7 +1295,15 @@ namespace Kerbulator {
 				if(!kalc.Functions.ContainsKey(id))
 					throw new Exception(pos + "unknown function "+ id);
 
-				List<Object> res = kalc.Functions[id].Execute(new List<Object>(args));
+                List<Object> res = new List<Object>();
+				List<Object> allOutputs = kalc.Functions[id].Execute(new List<Object>(args));
+                
+                //Only use outputs of type Value
+                for(int i = 0; i < allOutputs.Count; i++) {
+                    if(kalc.Functions[id].OutputTypes[i] == OutputType.Value)
+                        res.Add(allOutputs[i]);
+                }
+
 				if(res.Count == 1)
 					return res[0];
 				else

--- a/JITFunction.cs
+++ b/JITFunction.cs
@@ -209,12 +209,26 @@ namespace Kerbulator {
 				// No outputs specified, just return the value yielded by the last statement
 				result.Add(lastVal);
 
+            //Verify whether outputs are the correct types
+            VerifyResultTypes(result);
+
 			return result;
 		}
 
-		// With .NET 4.0, there is a BlockExpression. For now, we must hack our own
-		// implementation to execute multiple expressions.
-		public Object ExecuteBlock(Object[] statementResults) {
+        private void VerifyResultTypes(List<object> result) {
+            for(int i = 0; i < result.Count; i++) {
+                if(outputTypes[i] == OutputType.Maneuver) {
+                    object[] value = result[i] as object[];
+                    if(value == null || value.Length != 4) {
+                        throw new Exception($"In function {this.id} output variable {outs[i]} is not a list with 4 elements");
+                    }
+                }
+            }
+        }
+
+        // With .NET 4.0, there is a BlockExpression. For now, we must hack our own
+        // implementation to execute multiple expressions.
+        public Object ExecuteBlock(Object[] statementResults) {
 			return statementResults[statementResults.Length-1];
 		}
 

--- a/JITFunction.cs
+++ b/JITFunction.cs
@@ -201,9 +201,18 @@ namespace Kerbulator {
 
 			// Fetch the output variables from the locals dictionary
 			if(outs.Count > 0) {
-				foreach(string id in outs) {
-					if(!locals.ContainsKey(id))
-						throw new Exception("In function "+ this.id +": output variable "+ id +" is not defined");
+				for(int i=0; i<outs.Count; i++){
+					string id = outs[i];
+					if(!locals.ContainsKey(id)) {
+						switch(outputTypes[i]) {
+							case OutputType.Value:
+								throw new Exception("In function "+ this.id +": output variable "+ id +" is not defined");
+							case OutputType.Maneuver:
+								throw new Exception("In function "+ this.id +": maneuver variable "+ id +" is not defined");
+							case OutputType.Alarm:
+								throw new Exception("In function "+ this.id +": alarm variable "+ id +" is not defined");
+						}
+					}
 					result.Add(locals[id]);
 				}
 			} else

--- a/JITFunction.cs
+++ b/JITFunction.cs
@@ -265,7 +265,7 @@ namespace Kerbulator {
 					Consume();
 
 				// Parse out: statements
-				while(tokens.Count > 0 && tokens.Peek().type == TokenType.OUT || tokens.Peek().type == TokenType.MANEUVER) {
+				while(tokens.Count > 0 && tokens.Peek().type == TokenType.OUT || tokens.Peek().type == TokenType.MANEUVER ||tokens.Peek().type == TokenType.ALARM) {
                     Token token = Consume();
 
 
@@ -350,6 +350,9 @@ namespace Kerbulator {
                 case TokenType.MANEUVER:
                     outputTypes.Add(OutputType.Maneuver);
                     break;
+				case TokenType.ALARM:
+					outputTypes.Add(OutputType.Alarm);
+					break;
             }
         }
 

--- a/JITFunction.cs
+++ b/JITFunction.cs
@@ -23,6 +23,7 @@ namespace Kerbulator {
 		List<string> outDescriptions;
 		List<string> outPrefixes;
 		List<string> outPostfixes;
+		List<bool> outIsManeuverNode;
 
 		bool inError = false;
 		Exception error = null;
@@ -42,6 +43,7 @@ namespace Kerbulator {
 			this.outDescriptions = new List<string>();
 			this.outPrefixes = new List<string>();
 			this.outPostfixes = new List<string>();
+			this.outIsManeuverNode = new List<bool>();
 
 			this.locals = new Dictionary<string, Object>();
 			this.thisExpression = Expression.Constant(this);
@@ -85,7 +87,11 @@ namespace Kerbulator {
 			protected set {}
 		}
 
-		public bool InError {
+        public List<bool> OutIsManeuverNode { 
+			get { return outIsManeuverNode; }
+		}
+
+        public bool InError {
 			get { return inError; }
 			set { inError = value; if(!value) error = null; }
 		}
@@ -245,8 +251,10 @@ namespace Kerbulator {
 					Consume();
 
 				// Parse out: statements
-				while(tokens.Count > 0 && tokens.Peek().type == TokenType.OUT) {
-					Consume();
+				while(tokens.Count > 0 && tokens.Peek().type == TokenType.OUT || tokens.Peek().type == TokenType.OUT_MANEUVER) {
+					Token token = Consume();
+					bool isManeuverNode = token.type == TokenType.OUT_MANEUVER;
+
 
 					string prefix = null;
 					if(tokens.Count > 0 && tokens.Peek().type == TokenType.TEXT)
@@ -275,6 +283,7 @@ namespace Kerbulator {
 
 					Consume(TokenType.END);
 					outs.Add(id.val);
+					outIsManeuverNode.Add(isManeuverNode);
 					Kerbulator.DebugLine("Found OUT statement for "+ id.val);
 				}
 

--- a/Kerbulator.cs
+++ b/Kerbulator.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace Kerbulator {
 	public class Kerbulator {
-		public static bool DEBUG = false;
+		public static bool DEBUG = true;
 		public static void Debug(string s) {
 			if(DEBUG)
 				Console.Write(s);

--- a/Kerbulator.version
+++ b/Kerbulator.version
@@ -8,14 +8,14 @@
     },
     "VERSION": {
         "MAJOR": 0,
-        "MINOR": 4,
-        "PATCH": 4,
+        "MINOR": 5,
+        "PATCH": 0,
         "BUILD": 0
     },
     "KSP_VERSION": {
         "MAJOR": 1,
-        "MINOR": 4,
-        "PATCH": 4
+        "MINOR": 10,
+        "PATCH": 1, 
     },
     "KSP_VERSION_MIN": {
         "MAJOR": 1,
@@ -24,7 +24,7 @@
     },
     "KSP_VERSION_MAX": {
         "MAJOR": 1,
-        "MINOR": 4,
+        "MINOR": 10,
         "PATCH": 99
     }
 }

--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -435,9 +435,9 @@ namespace Kerbulator {
 
 			if(glue.CanAddNode()) {
 				if(GUILayout.Button(nodeIcon, defaultButton, GUILayout.Height(32))) {
-					Debug.Log("[Kerbulator] Adding maneuver node");
+					Debug.Log("[Kerbulator] Adding maneuver node(s)");
 					List<System.Object> output = Run();
-                    if(!RunFunction.InError) {
+                    if(!env.InError) {
                         List<System.Object> maneuvers = env.GetOutputsOfType(OutputType.Maneuver);
                         glue.PlaceNodes(RunFunction.Outs, maneuvers, output);
                     }
@@ -450,7 +450,7 @@ namespace Kerbulator {
 				if(GUILayout.Button(alarmIcon, defaultButton, GUILayout.Height(32))) {
 					Debug.Log("[Kerbulator] Adding alarm");
 					List<System.Object> output = Run();
-					if(!RunFunction.InError){
+					if(!env.InError){
 						List<System.Object> alarms = env.GetOutputsOfType(OutputType.Alarm);
                         glue.AddAlarms(RunFunction.Id, RunFunction.Outs, alarms, output);
 					}

--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -40,7 +40,7 @@ namespace Kerbulator {
 		string editFunctionContent = "";
 		string editFunctionName = "unnamed";
 		string functionFile = "unnamed.math";
-		string maneuverTemplate = "maneuver: node\n\nΔv_r = 0\nΔv_n = 0\nΔv_p = 0\nΔt = 0\n\nnode = [Δv_r, Δv_n, Δv_p, Δt]";
+		string maneuverTemplate = "maneuver: node\n\nΔv_p = 0\nΔv_n = 0\nΔv_r = 0\nΔt = 0\n\nnode = [Δv_p, Δv_n, Δv_r, Δt]";
 
 		// Running functions
 		bool running = false;

--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -3,12 +3,13 @@ using System.IO;
 using System.Collections.Generic;
 using System.Collections;
 using UnityEngine;
+using System.Linq;
 
 namespace Kerbulator {
 	/// <summary>Glue code to smooth over differences when plugin is loaded in
 	/// the Unity editor versus when it is loaded in the actual game.</summary>
 	public interface IGlue {
-		void PlaceNodes(List<string> ids, List<object> maneuverNodeIds, List<System.Object> output);
+		void PlaceNodes(List<string> ids, List<object> maneuverNodes, List<System.Object> output);
 		void AddGlobals(Kerbulator kalc);
 		Texture2D GetTexture(string id);
 		void ChangeState(bool open);
@@ -39,7 +40,7 @@ namespace Kerbulator {
 		string editFunctionContent = "";
 		string editFunctionName = "unnamed";
 		string functionFile = "unnamed.math";
-		string maneuverTemplate = "out maneuver: node\n\nΔv_r = 0\nΔv_n = 0\nΔv_p = 0\nΔt = 0\n\nnode = [Δv_r, Δv_n, Δv_p, Δt]";
+		string maneuverTemplate = "maneuver: node\n\nΔv_r = 0\nΔv_n = 0\nΔv_p = 0\nΔt = 0\n\nnode = [Δv_r, Δv_n, Δv_p, Δt]";
 
 		// Running functions
 		bool running = false;
@@ -436,12 +437,9 @@ namespace Kerbulator {
 				if(GUILayout.Button(nodeIcon, defaultButton, GUILayout.Height(32))) {
 					Debug.Log("[Kerbulator] Adding maneuver node");
 					List<System.Object> output = Run();
-					if(!RunFunction.InError)
-						glue.PlaceNodes(RunFunction.Outs, env.ManeuverOutput, output);
-
-					foreach(System.Object maneuverNodeOutput in env.ManeuverOutput)
-                    {
-
+                    if(!RunFunction.InError) {
+                        List<System.Object> maneuvers = env.GetOutputsOfType(OutputType.Maneuver);
+                        glue.PlaceNodes(RunFunction.Outs, maneuvers, output);
                     }
 
 					functionOutput = FormatOutput(env);

--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -756,10 +756,10 @@ namespace Kerbulator {
 			}
 		   
 			string desc = "";
-			for(int i=0; i<env.Output.Count-1; i++)
-				desc += env.func.OutPrefixes[i] + Kerbulator.FormatVar(env.Output[i]) + env.func.OutPostfixes[i] +"\n";
-			if(env.func.Outs.Count > 0)
-				desc += env.func.OutPrefixes[env.func.Outs.Count-1] + Kerbulator.FormatVar(env.Output[env.func.Outs.Count-1]) + env.func.OutPostfixes[env.func.Outs.Count-1] +"\n";
+			for(int i=0; i<env.Output.Count; i++){
+				if(env.func.OutputType == OutputType.Value)
+					desc += env.func.OutPrefixes[i] + Kerbulator.FormatVar(env.Output[i]) + env.func.OutPostfixes[i] +"\n";
+			}
 
 			return desc;
 		}

--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -14,7 +14,7 @@ namespace Kerbulator {
 		Texture2D GetTexture(string id);
 		void ChangeState(bool open);
 		void RunAsCoroutine(IEnumerator f);
-		void AddAlarm(string name, List<string> ids, List<System.Object> output);
+		void AddAlarms(string name, List<string> ids, List<System.Object> alarms, List<System.Object> output);
 		bool CanAddAlarm();
 		bool CanAddNode();
 		string GetFunctionDir();
@@ -450,8 +450,10 @@ namespace Kerbulator {
 				if(GUILayout.Button(alarmIcon, defaultButton, GUILayout.Height(32))) {
 					Debug.Log("[Kerbulator] Adding alarm");
 					List<System.Object> output = Run();
-					if(!RunFunction.InError)
-						glue.AddAlarm(RunFunction.Id, RunFunction.Outs, output);
+					if(!RunFunction.InError){
+						List<System.Object> alarms = env.GetOutputsOfType(OutputType.Alarm);
+                        glue.AddAlarms(RunFunction.Id, RunFunction.Outs, alarms, output);
+					}
 					functionOutput = FormatOutput(env);
 				}
 			}
@@ -757,7 +759,7 @@ namespace Kerbulator {
 		   
 			string desc = "";
 			for(int i=0; i<env.Output.Count; i++){
-				if(env.func.OutputType == OutputType.Value)
+				if(env.func.OutputTypes[i] == OutputType.Value)
 					desc += env.func.OutPrefixes[i] + Kerbulator.FormatVar(env.Output[i]) + env.func.OutPostfixes[i] +"\n";
 			}
 

--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -39,7 +39,7 @@ namespace Kerbulator {
 		string editFunctionContent = "";
 		string editFunctionName = "unnamed";
 		string functionFile = "unnamed.math";
-		string maneuverTemplate = "maneuver: node\n\nΔv_r = 0\nΔv_n = 0\nΔv_p = 0\nΔt = 0\n\nnode = [Δv_r, Δv_n, Δv_p, Δt]";
+		string maneuverTemplate = "out maneuver: node\n\nΔv_r = 0\nΔv_n = 0\nΔv_p = 0\nΔt = 0\n\nnode = [Δv_r, Δv_n, Δv_p, Δt]";
 
 		// Running functions
 		bool running = false;

--- a/KerbulatorGUI.cs
+++ b/KerbulatorGUI.cs
@@ -8,7 +8,7 @@ namespace Kerbulator {
 	/// <summary>Glue code to smooth over differences when plugin is loaded in
 	/// the Unity editor versus when it is loaded in the actual game.</summary>
 	public interface IGlue {
-		void PlaceNode(List<string> ids, List<System.Object> output);
+		void PlaceNodes(List<string> ids, List<object> maneuverNodeIds, List<System.Object> output);
 		void AddGlobals(Kerbulator kalc);
 		Texture2D GetTexture(string id);
 		void ChangeState(bool open);
@@ -39,7 +39,7 @@ namespace Kerbulator {
 		string editFunctionContent = "";
 		string editFunctionName = "unnamed";
 		string functionFile = "unnamed.math";
-		string maneuverTemplate = "out: Δv_r\nout: Δv_n\nout: Δv_p\nout: Δt\n\nΔv_r = 0\nΔv_n = 0\nΔv_p = 0\nΔt = 0";
+		string maneuverTemplate = "maneuver: node\n\nΔv_r = 0\nΔv_n = 0\nΔv_p = 0\nΔt = 0\n\nnode = [Δv_r, Δv_n, Δv_p, Δt]";
 
 		// Running functions
 		bool running = false;
@@ -437,7 +437,13 @@ namespace Kerbulator {
 					Debug.Log("[Kerbulator] Adding maneuver node");
 					List<System.Object> output = Run();
 					if(!RunFunction.InError)
-						glue.PlaceNode(RunFunction.Outs, output);
+						glue.PlaceNodes(RunFunction.Outs, env.ManeuverOutput, output);
+
+					foreach(System.Object maneuverNodeOutput in env.ManeuverOutput)
+                    {
+
+                    }
+
 					functionOutput = FormatOutput(env);
 				}
 			}

--- a/OutputType.cs
+++ b/OutputType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kerbulator {
+    public enum OutputType {
+        Value,
+        Maneuver
+    }
+}

--- a/OutputType.cs
+++ b/OutputType.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 namespace Kerbulator {
     public enum OutputType {
         Value,
-        Maneuver
+        Maneuver,
+        Alarm
     }
 }

--- a/Tokenizer.cs
+++ b/Tokenizer.cs
@@ -19,6 +19,7 @@ namespace Kerbulator {
 		TEXT,
 		IN,
 		OUT,
+		OUT_MANEUVER,
 		SKIP_NEWLINE,
 		PIECEWISE,
 		CONDITIONAL
@@ -109,7 +110,15 @@ namespace Kerbulator {
 					case ' ':
 					case '\t':
 					case '\r':
-						if(tok.type != TokenType.SKIP_NEWLINE) {
+						if (tok.val == "out" && line.Length > i + 10 && line.Substring(i, 10) == " maneuver:")
+                        {
+							tok.val += line.Substring(i, 10);
+							i += 9;
+
+							HandleToken(new Token(TokenType.OUT_MANEUVER, tok.val, functionName, lineno, col));
+							tok = new Token(functionName, lineno, col + 1);
+						}
+						else if(tok.type != TokenType.SKIP_NEWLINE) {
 							HandleToken(tok);
 							tok = new Token(functionName, lineno, col + 1);
 						}
@@ -310,11 +319,14 @@ namespace Kerbulator {
 
 					// In: and Out: statements
 					case ':':
-						if(tok.val == "in")
+						if (tok.val == "in")
 							HandleToken(new Token(TokenType.IN, tok.val, functionName, lineno, col));
-						else if(tok.val == "out")
+						else if (tok.val == "out")
 							HandleToken(new Token(TokenType.OUT, tok.val, functionName, lineno, col));
-						else {
+						else if (tok.val == "maneuver")
+							HandleToken(new Token(TokenType.OUT_MANEUVER, tok.val, functionName, lineno, col));
+						else
+						{
 							HandleToken(tok);
 							HandleToken(new Token(TokenType.COLON, tok.val, functionName, lineno, col));
 						}

--- a/Tokenizer.cs
+++ b/Tokenizer.cs
@@ -20,6 +20,7 @@ namespace Kerbulator {
 		IN,
 		OUT,
 		MANEUVER,
+		ALARM,
 		SKIP_NEWLINE,
 		PIECEWISE,
 		CONDITIONAL
@@ -317,6 +318,8 @@ namespace Kerbulator {
                             HandleToken(new Token(TokenType.OUT, tok.val, functionName, lineno, col));
                         else if(tok.val == "maneuver")
                             HandleToken(new Token(TokenType.MANEUVER, tok.val, functionName, lineno, col));
+						else if(tok.val == "alarm")
+							HandleToken(new Token(TokenType.ALARM, tok.val, functionName, lineno, col));
                         else {
                             HandleToken(tok);
                             HandleToken(new Token(TokenType.COLON, tok.val, functionName, lineno, col));

--- a/Tokenizer.cs
+++ b/Tokenizer.cs
@@ -19,7 +19,7 @@ namespace Kerbulator {
 		TEXT,
 		IN,
 		OUT,
-		OUT_MANEUVER,
+		MANEUVER,
 		SKIP_NEWLINE,
 		PIECEWISE,
 		CONDITIONAL
@@ -110,15 +110,7 @@ namespace Kerbulator {
 					case ' ':
 					case '\t':
 					case '\r':
-						if (tok.val == "out" && line.Length > i + 10 && line.Substring(i, 10) == " maneuver:")
-                        {
-							tok.val += line.Substring(i, 10);
-							i += 9;
-
-							HandleToken(new Token(TokenType.OUT_MANEUVER, tok.val, functionName, lineno, col));
-							tok = new Token(functionName, lineno, col + 1);
-						}
-						else if(tok.type != TokenType.SKIP_NEWLINE) {
+						if(tok.type != TokenType.SKIP_NEWLINE) {
 							HandleToken(tok);
 							tok = new Token(functionName, lineno, col + 1);
 						}
@@ -319,17 +311,16 @@ namespace Kerbulator {
 
 					// In: and Out: statements
 					case ':':
-						if (tok.val == "in")
-							HandleToken(new Token(TokenType.IN, tok.val, functionName, lineno, col));
-						else if (tok.val == "out")
-							HandleToken(new Token(TokenType.OUT, tok.val, functionName, lineno, col));
-						else if (tok.val == "maneuver")
-							HandleToken(new Token(TokenType.OUT_MANEUVER, tok.val, functionName, lineno, col));
-						else
-						{
-							HandleToken(tok);
-							HandleToken(new Token(TokenType.COLON, tok.val, functionName, lineno, col));
-						}
+                        if(tok.val == "in")
+                            HandleToken(new Token(TokenType.IN, tok.val, functionName, lineno, col));
+                        else if(tok.val == "out")
+                            HandleToken(new Token(TokenType.OUT, tok.val, functionName, lineno, col));
+                        else if(tok.val == "maneuver")
+                            HandleToken(new Token(TokenType.MANEUVER, tok.val, functionName, lineno, col));
+                        else {
+                            HandleToken(tok);
+                            HandleToken(new Token(TokenType.COLON, tok.val, functionName, lineno, col));
+                        }
 
 						tok = new Token(functionName, lineno, col + 1);
 						break;

--- a/UnityGlue.cs
+++ b/UnityGlue.cs
@@ -47,7 +47,7 @@ namespace Kerbulator {
 				gui.OnDestroy();
 		}
 
-		public void AddAlarm(string name, List<string> ids, List<System.Object> output) {
+		public void AddAlarms(string name, List<string> ids, List<System.Object> alarms, List<System.Object> output) {
 		}
 
 		public bool CanAddAlarm() {

--- a/UnityGlue.cs
+++ b/UnityGlue.cs
@@ -28,7 +28,7 @@ namespace Kerbulator {
 		public void AddGlobals(Kerbulator kalc) {
 		}
 
-		public void PlaceNode(List<string> ids, List<System.Object> output) {
+		public void PlaceNodes(List<string> ids, List<object> maneuverNode, List<System.Object> output) {
 		}
 
 		public Texture2D GetTexture(string id) {

--- a/doc/langref.mkd
+++ b/doc/langref.mkd
@@ -34,7 +34,7 @@ An output specification is of the following forms:
 
 If no output specifications are given, the result produced by the execution of the last statement of the function is used as output of the function.
 
-Outputs can also take the form of `alarm:` and `maneuver:` which can be used to create maneuver nodes and alarms. This will be expanded on in the sections Creating maneuver nodes and Setting alarms
+Outputs can also take the form of `alarm:` and `maneuver:` which can be used to create maneuver nodes and alarms. This will be expanded on in the sections "Creating maneuver nodes" and "Setting alarms".
 
 ### Comments
 A `#` character is ignored and everything following the character up to the end of the line is also ignored. You can use this to place comments in your code. For example:
@@ -240,17 +240,25 @@ And so are these:
     someFunction (1)
     
 #### Creating maneuver nodes
-To create a maneuver nodes with Kerbulator the `maneuver` keyword is used, it specifies that an output should be used to create a maneuver node. The maneuver output specification is usually of the following form but any variation with prefix, postfix and description will work.
+To create a maneuver nodes with Kerbulator the `maneuver` keyword is used, it specifies that a variable should be used to create a maneuver node. The maneuver output specification is usually of the following form:
 
 `maneuver: identifier`
 
-Maneuver outputs are required to be lists with 4 elements. These four elements denote `[Δv_p, Δv_n, Δv_r, Δt]`.
+Maneuvers need to be declared at the top of the function, in a similar fashion as `in:` and `out:` declarations. Maneuvers may also be given a prefix, postfix and description, although they are currently not used, for example:
+
+ `maneuver: identifier "postfix" "Short description"`
+
+Variables indicated by the `maneuver:` declaration are required to be lists with 4 elements. These four elements denote `[Δv_p, Δv_n, Δv_r, Δt]`:
+
 Value  | Description
 -------|----------
 `Δv_p` | Change in velocity in the prograde direction (straight ahead)
 `Δv_n` | Change in velocity in the normal direction (up)
 `Δv_r` | Change in velocity in the radial direction (away from the planet)
 `Δt`   | Time at which to perform the burn (where 0 means right now)
+
+Note that variables marked as `maneuver` are not function outputs. They are only used to create maneuver nodes and are otherwise inaccessible outside of the function.
+
 
 #### Setting alarms (KAC)
 For this to work the mod Kerbal Alarm Clock (KAC) has to be installed.

--- a/doc/langref.mkd
+++ b/doc/langref.mkd
@@ -34,6 +34,8 @@ An output specification is of the following forms:
 
 If no output specifications are given, the result produced by the execution of the last statement of the function is used as output of the function.
 
+Outputs can also take the form of `alarm:` and `maneuver:` which can be used to create maneuver nodes and alarms. This will be expanded on in the sections Creating maneuver nodes and Setting alarms
+
 ### Comments
 A `#` character is ignored and everything following the character up to the end of the line is also ignored. You can use this to place comments in your code. For example:
 
@@ -236,6 +238,29 @@ And so are these:
     someFunction 1
     someFunction(1)
     someFunction (1)
+    
+#### Creating maneuver nodes
+To create a maneuver nodes with Kerbulator the `maneuver` keyword is used, it specifies that an output should be used to create a maneuver node. The maneuver output specification is usually of the following form but any variation with prefix, postfix and description will work.
+
+`maneuver: identifier`
+
+Maneuver outputs are required to be lists with 4 elements. These four elements denote `[Δv_p, Δv_n, Δv_r, Δt]`.
+Value  | Description
+-------|----------
+`Δv_p` | Change in velocity in the prograde direction (straight ahead)
+`Δv_n` | Change in velocity in the normal direction (up)
+`Δv_r` | Change in velocity in the radial direction (away from the planet)
+`Δt`   | Time at which to perform the burn (where 0 means right now)
+
+#### Setting alarms (KAC)
+For this to work the mod Kerbal Alarm Clock (KAC) has to be installed.
+
+Similarly to creating maneuver nodes there is a keyword to specify alarm outputs. For this the `alarm` keyword is used instead.
+`alarm: identifier`
+
+Alarm outputs are numbers sepcifying the universal time counting up from the start of the game. If a relative time is preferred the global value `UT` can come in handy.
+
+`someAlarm = UT + Δt`
 
 #### Build-in functions
 Apart from the functions you write yourself, Kerbulator supplies the following build-in functions:

--- a/doc/manual.mkd
+++ b/doc/manual.mkd
@@ -171,6 +171,8 @@ Name   | Description
 
 All these values may be negative, except for Δt; creating nodes in the past really confuses KSP so Kerbulator will not do it. Also, not all of these have to be defined by the function. Values that are not defined will be set to 0.
 
+Maneuver nodes can also be defined by using the maneuver output specification `maneuver: <identifier>`, this tells Kerbulator to use the output to create a maneuver node. When using this notation the output has to be a list with the values `[Δv_r, Δv_n, Δv_p, Δt]`. This can be used to make multiple maneuver nodes from one script.
+
 Bob's function is almost ready to be used to create a maneuver node, he just needs to change his `Δv` variable to `Δv_p`. Now Bob can press the node button (maneuver node icon) in the run window in order to create the node. Happy flying Bob!
 
 ### Calling functions with multiple outputs

--- a/doc/manual.mkd
+++ b/doc/manual.mkd
@@ -156,24 +156,40 @@ He saves his function and presses the `Run` button. Behold! Kerbulator faithfull
 
 ### Creating maneuver nodes
 
-Bob is just about to create a maneuver node manually when he realizes that Kerbulator has the ability to create it for him. However, he needs to make a small change to his code. When Kerbulator is asked to create a node based on the result of a function, it runs the function and then takes a look at which variables are outputs. It uses the following variables to create the node:
+Bob is just about to create a maneuver node manually when he realizes that Kerbulator has the ability to create it for him. However, he needs to make a small change to his code. In the same manner as he defined the inputs and outputs, Bob can define maneuvers at the top of the function by writing `maneuver: <identifier> "<description>"`. When Kerbulator is asked to create a node based on the result of a function, it runs the function and then takes a look at which variables are flagged as describing maneuvers. A maneuver variable needs to be a list of four values in the form of: `[Δv_r, Δv_n, Δv_p, Δt]`, where the values mean:
 
-Name   | Description
+Value  | Description
 -------|----------
-`Δv_r` | Change in velocity in the radial direction (away from the planet)
-`dv_r` | Same as `Δv_r`
-`Δv_n` | Change in velocity in the normal direction (up)
-`dv_n` | Same as `Δv_n`
 `Δv_p` | Change in velocity in the prograde direction (straight ahead)
-`dv_p` | Same as `Δv_p`
+`Δv_n` | Change in velocity in the normal direction (up)
+`Δv_r` | Change in velocity in the radial direction (away from the planet)
 `Δt`   | Time at which to perform the burn (where 0 means right now)
-`dt`   | Same as `Δt`
 
-All these values may be negative, except for Δt; creating nodes in the past really confuses KSP so Kerbulator will not do it. Also, not all of these have to be defined by the function. Values that are not defined will be set to 0.
+All these values may be negative, except for value 4 (Δt); creating nodes in the past really confuses KSP so Kerbulator will not do it. Also, not all of these have to be defined by the function.
 
-Maneuver nodes can also be defined by using the maneuver output specification `maneuver: <identifier>`, this tells Kerbulator to use the output to create a maneuver node. When using this notation the output has to be a list with the values `[Δv_r, Δv_n, Δv_p, Δt]`. This can be used to make multiple maneuver nodes from one script.
+For Bob's function to be ablt to create a maneuver nodes, he first defines the maneuver variable at the top and creates the variable at the bottom:
 
-Bob's function is almost ready to be used to create a maneuver node, he just needs to change his `Δv` variable to `Δv_p`. Now Bob can press the node button (maneuver node icon) in the run window in order to create the node. Happy flying Bob!
+    out: Δv "Amount of Δv to burn for"
+    out: Δt "Time at which to initiate burn (0 means right now)"
+    maneuver: circularize "Maneuver to perform the circularization burn"
+
+    # Calculate our velocity when we reach apoapsis
+    v1 = orbital_velocity(Craft.Pe, Craft.Ap, Craft.Ap)
+
+    # Calculate how fast we should be going were we in a circular orbit
+    v2 = orbital_velocity(Craft.Ap, Craft.Ap, Craft.Ap)
+
+    # Calculate Δv required to circularize our orbit
+    Δv = v2 - v1
+
+    # Burn at apoapsis. Kerbulator has a global for this.
+    Δt = Craft.TimeToAp
+
+    # Information to create a maneuver node.
+    circularize = [Δv, 0, 0, Δt]
+
+Now Bob can press the node button (maneuver node icon) in the run window in order to create the node. Happy flying Bob!
+
 
 ### Calling functions with multiple outputs
 

--- a/doc/manual.mkd
+++ b/doc/manual.mkd
@@ -256,10 +256,11 @@ which will try to find a value for `x` so that the equation holds.
 
 ### Creating alarms
 
-If Bob brings his trusty Kerbal Alarm Clock, he can use Kerbulator to set an alarm, based on some calculation. This works similarly to creating maneuver nodes. When Kerbulator is asked to set an alarm, it runs the function and takes a look at the outpus. It uses the following variables to create the alarm:
+If Bob brings his trusty Kerbal Alarm Clock, he can use Kerbulator to set an alarm, based on some calculation. This works similarly to creating maneuver nodes, by writing `alarm: <identifier> "<description>"`. Alarm outputs are given at global game time. By using the `UT` global value, relative times are also usable like so:
+
+`someAlarm = UT + Δt`
 
 Name   | Description
 -------|----------
-`Δt`   | Alarm will be set Δt second from now
-`dt`   | Same as `Δt`
-`UT`   | Alarm will be set at time UT (global game time)
+`Δt`   | Alarm will be set Δt seconds from now
+`UT`   | A global value returning the current time in global game time

--- a/doc/manual.mkd
+++ b/doc/manual.mkd
@@ -156,7 +156,7 @@ He saves his function and presses the `Run` button. Behold! Kerbulator faithfull
 
 ### Creating maneuver nodes
 
-Bob is just about to create a maneuver node manually when he realizes that Kerbulator has the ability to create it for him. However, he needs to make a small change to his code. In the same manner as he defined the inputs and outputs, Bob can define maneuvers at the top of the function by writing `maneuver: <identifier> "<description>"`. When Kerbulator is asked to create a node based on the result of a function, it runs the function and then takes a look at which variables are flagged as describing maneuvers. A maneuver variable needs to be a list of four values in the form of: `[Δv_r, Δv_n, Δv_p, Δt]`, where the values mean:
+Bob is just about to create a maneuver node manually when he realizes that Kerbulator has the ability to create it for him. However, he needs to make a small change to his code. In the same manner as he defined the inputs and outputs, Bob can define maneuvers at the top of the function by writing `maneuver: <identifier> "<description>"`. When Kerbulator is asked to create a node based on the result of a function, it runs the function and then takes a look at which variables are flagged as describing maneuvers. A maneuver variable needs to be a list of four values in the form of: `[Δv_p, Δv_n, Δv_r, Δt]`, where the values mean:
 
 Value  | Description
 -------|----------

--- a/doc/manual.mkd
+++ b/doc/manual.mkd
@@ -167,7 +167,7 @@ Value  | Description
 
 All these values may be negative, except for value 4 (Δt); creating nodes in the past really confuses KSP so Kerbulator will not do it. Also, not all of these have to be defined by the function.
 
-For Bob's function to be able to create a maneuver nodes, he first defines the maneuver variable at the top and creates the variable at the bottom:
+For Bob's function to be able to create a maneuver nodes, he first declares the maneuver variable at the top and assigns a list to the variable at the bottom:
 
     out: Δv "Amount of Δv to burn for"
     out: Δt "Time at which to initiate burn (0 means right now)"

--- a/doc/manual.mkd
+++ b/doc/manual.mkd
@@ -167,7 +167,7 @@ Value  | Description
 
 All these values may be negative, except for value 4 (Δt); creating nodes in the past really confuses KSP so Kerbulator will not do it. Also, not all of these have to be defined by the function.
 
-For Bob's function to be ablt to create a maneuver nodes, he first defines the maneuver variable at the top and creates the variable at the bottom:
+For Bob's function to be able to create a maneuver nodes, he first defines the maneuver variable at the top and creates the variable at the bottom:
 
     out: Δv "Amount of Δv to burn for"
     out: Δt "Time at which to initiate burn (0 means right now)"


### PR DESCRIPTION
This pull request aims to add support for multiple maneuver nodes  while maintaining backwards compatibility. Which should resolve #37 
 
It works by designating outputs as maneuvers with a new **maneuver** keyword like so
`out maneuver: node1`

The game glue then requires these maneuver outputs to be of type list with 4 elements
`node1 = [dv_r, dv_n, dv_p, dt]`

The order of maneuver nodes is inferred by ksp from the time (`dt`) component